### PR TITLE
Unmute GameGridItem video preview

### DIFF
--- a/layer_grid/GameGrid.qml
+++ b/layer_grid/GameGrid.qml
@@ -5,6 +5,7 @@ FocusScope {
   id: root
 
   // Options
+  property bool detailsActive: false
   property int numColumns: 4
 
   property alias gridWidth: grid.width
@@ -133,6 +134,7 @@ FocusScope {
       width: GridView.view.cellWidth
       height: GridView.view.cellHeight
       selected: GridView.isCurrentItem
+      mute: root.detailsActive
       //collection: api.currentCollection
 
       game: modelData

--- a/layer_grid/GameGridItem.qml
+++ b/layer_grid/GameGridItem.qml
@@ -12,6 +12,8 @@ Item {
   property var collection: api.currentCollection
   property bool steam: false
 
+  property bool mute: false
+
   signal details
   signal clicked
 
@@ -175,7 +177,7 @@ Item {
         source: game.assets.videos.length ? game.assets.videos[0] : ""
         anchors.fill: parent
         fillMode: VideoOutput.PreserveAspectCrop
-        muted: true
+        muted: root.mute
         loops: MediaPlayer.Infinite
         autoPlay: true
       }

--- a/theme.qml
+++ b/theme.qml
@@ -173,6 +173,8 @@ FocusScope {
             left: parent.left; right: parent.right
           }
 
+          detailsActive: gamedetails.active
+
           onLaunchRequested: api.currentGame.launch()
           onNextCollection: api.collections.incrementIndex()
           onPrevCollection: api.collections.decrementIndex()


### PR DESCRIPTION
This is based entirely on preference, but, I've added some code to mute and unmute the video preview on GameGridItem when GameGridDetails is active.

I don't know QML, so there might be a better way to do this. Feel free to edit/reject.