### PR TITLE
Fallback to boxFront if screenshots n/a

### DIFF
--- a/layer_grid/GameGridItem.qml
+++ b/layer_grid/GameGridItem.qml
@@ -138,11 +138,11 @@ Item {
       }
 
       asynchronous: true
-      visible: game.assets.screenshots[0] || ""
+      visible: game.assets.screenshots[0] || game.assets.boxFront || ""
 
       smooth: true
 
-      source: (steam) ? game.assets.logo : game.assets.screenshots[0] || ""
+      source: (steam) ? game.assets.logo : game.assets.screenshots[0] || game.assets.boxFront || ""
       sourceSize { width: 256; height: 256 }
       fillMode: Image.PreserveAspectCrop
 


### PR DESCRIPTION
Displays boxFront images in case of game.assets.screenshots are not available. 
Suitable for those who still use EmulationStation settings only.