### PR TITLE
Last played game index save per collection

### DIFF
--- a/layer_grid/GameGrid.qml
+++ b/layer_grid/GameGrid.qml
@@ -70,6 +70,10 @@ FocusScope {
 
   }
 
+  onCurrentGameIdxChanged: {
+    grid.currentIndex = currentGameIdx
+  }
+
 
 
   GridView {
@@ -94,7 +98,6 @@ FocusScope {
     //snapMode: GridView.SnapOneItem
 
     model: collectionData ? collectionData.games : []
-    currentIndex: currentGameIdx
     onCurrentIndexChanged: {
       //if (api.currentCollection) api.currentCollection.games.index = currentIndex;
       navSound.play()

--- a/theme.qml
+++ b/theme.qml
@@ -27,15 +27,17 @@ FocusScope {
   property var currentCollection: api.collections.get(collectionIndex)
 
   function nextCollection () {
-    collectionIndex = modulo(collectionIndex + 1, api.collections.count);
+    jumpToCollection(collectionIndex + 1);
   }
 
   function prevCollection() {
-      collectionIndex = modulo(collectionIndex - 1, api.collections.count);
+    jumpToCollection(collectionIndex - 1);
   }
 
-  function jumpToCollection(id) {
-    collectionIndex = id;
+  function jumpToCollection(idx) {
+    api.memory.set('gameCollIndex' + collectionIndex, currentGameIndex); // save game index of current collection
+    collectionIndex = modulo(idx, api.collections.count); // new collection index
+    currentGameIndex = api.memory.get('gameCollIndex' + collectionIndex) || 0; // restore game index for newly selected collection
   }
 
   // End collection switching //
@@ -59,12 +61,12 @@ FocusScope {
 
   Component.onCompleted: {
     collectionIndex = api.memory.get('collectionIndex') || 0;
-    currentGameIndex = api.memory.get('gameIndex') || 0;
+    currentGameIndex = api.memory.get('gameCollIndex' + collectionIndex) || 0;
   }
 
   function launchGame() {
     api.memory.set('collectionIndex', collectionIndex);
-    api.memory.set('gameIndex', currentGameIndex);
+    api.memory.set('gameCollIndex' + collectionIndex, currentGameIndex);
     currentGame.launch();
   }
 


### PR DESCRIPTION
Proposed change ensures saving last-game-played index for each particular collection: 
currentGameIndex variable is saved to "gameCollIndexN", where N is collection index. The saving is done only when switching among collections/systems. You may change it altogether to conform to your coding style. 

Yet another problem with last game selection persists: 
When a game is selected by mouse-click, suddenly, saving indices stops working - index is always 0, until a game is launched; then, after returning to Pegasus front-end, everything continues working as usual. No such behavior is observable when using a keyboard or a game-pad. I have looked into the code (GameGrid.qml), and I see no obvious reason for the glitch. Both, the keyboard and mouse events are processed with the same "onCurrentIndexChanged" handler. Because I am not QML savvy (in fact, I first touched QML just 2 days ago :c)), I may be missing something.. 