### PR TITLE
Another fix for the last-played-game index

### DIFF
--- a/theme.qml
+++ b/theme.qml
@@ -51,6 +51,9 @@ FocusScope {
 
   function changeGameIndex (idx) {
     currentGameIndex = idx
+    if (collectionIndex && idx) {
+      api.memory.set('gameIndex' + collectionIndex, idx);
+    }
   }
 
   // End game switching //


### PR DESCRIPTION
This fix covers special scenario: 
Previously, when user changed a game selection, but never selected another collection and then closed the front-end app, the last played game index was not saved.