### PR TITLE
Automatic selection after front-end start

### DIFF
--- a/layer_grid/GameGrid.qml
+++ b/layer_grid/GameGrid.qml
@@ -105,6 +105,10 @@ FocusScope {
 
     }
 
+    Component.onCompleted: {
+      positionViewAtIndex(currentIndex, GridView.Contain);
+    }
+
     Keys.onPressed: {
         if (api.keys.isAccept(event) && !event.isAutoRepeat) {
             event.accepted = true;


### PR DESCRIPTION
Upon front-end start, and in the case of larger game lists, when the last selected game was out of scope - selection was not scrolled to an item. Only after user input (keyboard, mouse, or game-pad), the selection was highlighted. This fixes it.