### PR TITLE
Quick search by holding Alt-key

### DIFF
--- a/layer_grid/GameGrid.qml
+++ b/layer_grid/GameGrid.qml
@@ -12,6 +12,7 @@ FocusScope {
   property var collectionData
   property var gameData
   property int currentGameIdx
+  property string jumpToPattern: ''
 
   signal launchRequested
   signal menuRequested
@@ -135,9 +136,30 @@ FocusScope {
         if (api.keys.isNextPage(event)) {
             collectionNext()
         }
-        if (event.modifiers === Qt.AltModifier && event.text) {
-            event.accepted = true;
-            api.currentCollection.games.jumpToLetter(event.text);
+        if (event.key == Qt.Key_Alt) { // single Alt key
+          jumpToPattern = ''
+        }
+        if ((event.modifiers & Qt.AltModifier) && event.text) {
+          event.accepted = true;
+          jumpToPattern += event.text.toLowerCase();
+          var match = false;
+          for (var idx = 0; idx < model.count; idx++) { // search title starting-with pattern
+            var lowTitle = model.get(idx).title.toLowerCase();
+            if (lowTitle.indexOf(jumpToPattern) == 0) {
+              currentIndex = idx;
+              match = true;
+              break;
+            }
+          }
+          if (!match) { // no match - try to search title containing pattern
+            for (var idx = 0; idx < model.count; idx++) {
+              var lowTitle = model.get(idx).title.toLowerCase();
+              if (lowTitle.indexOf(jumpToPattern) != -1) {
+                currentIndex = idx;
+                break;
+              }
+            }
+          }
         }
     }
 


### PR DESCRIPTION
Search for a title:     Hold down Alt-key and type a text. 
New search:      Release the Alt-key and repeat the process above. 

This is not a filtering tool, it's just a quick search tool for a game title, where a typed text pattern is at first compared with title staring-with text, then only when there is no match, the tool is searching again, this time for any text match. 
TODO: 
Someone may decide to add functionality for displaying a fancy looking search text pattern overlaying somewhere in the middle (or the top) of the screen to see what has just been typed (jumpToPattern string). New event handling Keys.onReleased/Alt-key would dismiss the overlay.