### PR TITLE
Tiny fix to collection names in text

### DIFF
--- a/GameDetails/GameView.qml
+++ b/GameDetails/GameView.qml
@@ -444,7 +444,7 @@ id: root
             horizontalAlignment: Text.AlignHLeft
             verticalAlignment: Text.AlignVCenter
             elide: Text.ElideRight
-            visible: platformlogo.source === ""
+            visible: platformlogo.status == Image.Error
 
             // Mouse/touch functionality
             MouseArea {

--- a/Global/HeaderBar.qml
+++ b/Global/HeaderBar.qml
@@ -94,7 +94,7 @@ id: root
             horizontalAlignment: Text.AlignHLeft
             verticalAlignment: Text.AlignVCenter
             elide: Text.ElideRight
-            visible: platformlogo.source === ""
+            visible: platformlogo.status == Image.Error
 
             // Mouse/touch functionality
             MouseArea {

--- a/ShowcaseView/ShowcaseViewMenu.qml
+++ b/ShowcaseView/ShowcaseViewMenu.qml
@@ -406,7 +406,7 @@ id: root
 
                     text: modelData.name
                     anchors { fill: parent; margins: vpx(10) }
-                    color: "white"
+                    color: theme.text
                     opacity: selected ? 1 : 0.2
                     Behavior on opacity { NumberAnimation { duration: 100 } }
                     font.pixelSize: vpx(18)

--- a/ShowcaseView/ShowcaseViewMenu.qml
+++ b/ShowcaseView/ShowcaseViewMenu.qml
@@ -413,7 +413,7 @@ id: root
                     font.family: subtitleFont.name
                     font.bold: true
                     style: Text.Outline; styleColor: theme.main
-                    visible: collectionlogo.source == ""
+                    visible: collectionlogo.status == Image.Error
                     anchors.centerIn: parent
                     elide: Text.ElideRight
                     wrapMode: Text.WordWrap


### PR DESCRIPTION
This is a tiny fix to how the visibility is set for the text caption for collection names, in case the collection name is not one of the systems with resource logos.
Previously, visibility was set dependent on the source of the logo's image being empty. However, It'll never be empty as part of the source content is the path to the base directory ("../assets/images/logospng/") resulting in collections with non-standard names having their label invisible.
This simply checks for the image loading status being an error.

There is also a small text colour set to the theme colour (because I'm obsessive, feel free to dump that ...)