### PR TITLE
Add persistent title and better boxart

### DIFF
--- a/Global/BoxArtGridItem.qml
+++ b/Global/BoxArtGridItem.qml
@@ -194,10 +194,11 @@ id: root
     Component {
     id: loaderspinner
     
-        Image {        
+        Image {
             source: "../assets/images/loading.png"
             width: vpx(50)
             height: vpx(50)
+            sourceSize { width: vpx(50); height: vpx(50) }
             RotationAnimator on rotation {
                 loops: Animator.Infinite;
                 from: 0;

--- a/Global/BoxArtGridItem.qml
+++ b/Global/BoxArtGridItem.qml
@@ -77,7 +77,7 @@ id: root
             asynchronous: true
             source: boxArt(gameData)
             sourceSize { width: root.width; height: root.height }
-            fillMode: Image.Stretch
+            fillMode: Image.PreserveAspectFit
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.verticalCenter: parent.verticalCenter
 
@@ -103,14 +103,15 @@ id: root
         }
 
         Rectangle {
-            id: regborder
+        id: regborder
 
-                anchors.fill: parent
-                color: "transparent"
-                border.width: vpx(1)
-                border.color: "white"
-                opacity: 0.1
-            }
+            anchors.fill: parent
+            color: "transparent"
+            border.width: vpx(1)
+            border.color: "white"
+            opacity: 0.1
+            visible: false
+        }
 
         Rectangle {
         id: overlay
@@ -120,6 +121,7 @@ id: root
             anchors.centerIn: screenshot
             color: screenshot.source == "" ? theme.secondary : "black"
             opacity: screenshot.source == "" ? 1 : selected ? 0.0 : 0.2
+            visible: false
         }
 
         

--- a/Global/BoxArtGridItem.qml
+++ b/Global/BoxArtGridItem.qml
@@ -14,7 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with this program. If not, see <http://www.gnu.org/licenses/>.
 
-import QtQuick 2.0
+import QtQuick 2.8
+import QtGraphicalEffects 1.12
 
 Item {
 id: root
@@ -59,47 +60,74 @@ id: root
 
     signal activate()
     signal highlighted()
-                       
-    Image {
-    id: screenshot
-   
+
+    Item 
+    {
+    id: container
+
         anchors.fill: parent
         anchors.margins: vpx(6)
+        Behavior on opacity { NumberAnimation { duration: 200 } }
+                       
+        Image {
+        id: screenshot
+            anchors.fill: parent
+            anchors.margins: vpx(2)
 
-        asynchronous: true
-        source: boxArt(gameData)
-        sourceSize { width: 1920/columns; height: 1920/columns }
-        fillMode: Image.PreserveAspectFit
-        smooth: true
-        anchors.horizontalCenter: parent.horizontalCenter
-        anchors.verticalCenter: parent.verticalCenter
+            asynchronous: true
+            source: boxArt(gameData)
+            sourceSize { width: root.width; height: root.height }
+            fillMode: Image.Stretch
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.verticalCenter: parent.verticalCenter
 
-        Rectangle {
-        id: favicon
+            Rectangle {
+            id: favicon
 
-            anchors { 
-                right: parent.right; rightMargin: vpx(7); 
-                top: parent.top; topMargin: vpx(7) 
-            }
-            width: vpx(20)
-            height: width
-            radius: width/2
-            color: theme.accent
-            visible: gameData.favorite
-            Image {
-                source: "../assets/images/favicon.svg"
-                asynchronous: true
-                anchors.fill: parent
-                anchors.margins: vpx(4)            
+                anchors { 
+                    right: parent.right; rightMargin: vpx(7); 
+                    top: parent.top; topMargin: vpx(7) 
+                }
+                width: vpx(20)
+                height: width
+                radius: width/2
+                color: theme.accent
+                visible: gameData.favorite
+                Image {
+                    source: "../assets/images/favicon.svg"
+                    asynchronous: true
+                    anchors.fill: parent
+                    anchors.margins: vpx(4)            
+                }
             }
         }
+
+        Rectangle {
+            id: regborder
+
+                anchors.fill: parent
+                color: "transparent"
+                border.width: vpx(1)
+                border.color: "white"
+                opacity: 0.1
+            }
+
+        Rectangle {
+        id: overlay
+        
+            width: screenshot.paintedWidth
+            height: screenshot.paintedHeight
+            anchors.centerIn: screenshot
+            color: screenshot.source == "" ? theme.secondary : "black"
+            opacity: screenshot.source == "" ? 1 : selected ? 0.0 : 0.2
+        }
+
+        
     }
 
     Loader {
         active: selected
-        width: screenshot.paintedWidth + vpx(4)
-        height: screenshot.paintedHeight + vpx(4)
-        anchors.centerIn: screenshot
+        anchors.fill: container
         sourceComponent: border
         asynchronous: true
     }
@@ -108,6 +136,30 @@ id: root
     id: border
 
         ItemBorder { }
+    }
+
+    Text {
+    id: title
+
+        text: modelData ? modelData.title : ''
+        color: theme.text
+        font {
+            family: subtitleFont.name
+            pixelSize: vpx(12)
+            bold: true
+        }
+
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+
+        anchors {
+            top: container.bottom; topMargin: vpx(8)
+            left: parent.left; right: parent.right
+        }
+
+        opacity: 0.5
+        visible: settings.AlwaysShowTitles === "Yes" && !selected
     }
 
     Text {
@@ -129,6 +181,30 @@ id: root
         lineHeight: 0.8
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
+    }
+
+    Loader {
+    id: spinnerloader
+
+        anchors.centerIn: parent
+        active: screenshot.status === Image.Loading
+        sourceComponent: loaderspinner
+    }
+
+    Component {
+    id: loaderspinner
+    
+        Image {        
+            source: "../assets/images/loading.png"
+            width: vpx(50)
+            height: vpx(50)
+            RotationAnimator on rotation {
+                loops: Animator.Infinite;
+                from: 0;
+                to: 360;
+                duration: 500
+            }
+        }
     }
 
     // List specific input

--- a/Global/DynamicGridItem.qml
+++ b/Global/DynamicGridItem.qml
@@ -233,6 +233,7 @@ id: root
             source: "../assets/images/loading.png"
             width: vpx(50)
             height: vpx(50)
+            sourceSize { width: vpx(50); height: vpx(50) }
             RotationAnimator on rotation {
                 loops: Animator.Infinite;
                 from: 0;

--- a/Global/DynamicGridItem.qml
+++ b/Global/DynamicGridItem.qml
@@ -153,6 +153,31 @@ id: root
     }
 
     Text {
+    id: title
+
+        text: modelData ? modelData.title : ''
+        color: theme.text
+        font {
+            family: subtitleFont.name
+            pixelSize: vpx(12)
+            bold: true
+        }
+
+        elide: Text.ElideRight
+        horizontalAlignment: Text.AlignHCenter
+        verticalAlignment: Text.AlignVCenter
+
+        anchors {
+            top: container.bottom; topMargin: vpx(8)
+        }
+
+        width: parent.width
+
+        opacity: 0.2
+        visible: settings.AlwaysShowTitles === "Yes" && !selected
+    }
+
+    Text {
     id: platformname
 
         text: modelData.title
@@ -172,8 +197,6 @@ id: root
         horizontalAlignment: Text.AlignHCenter
         verticalAlignment: Text.AlignVCenter
     }
-
-    
 
     Rectangle {
     id: favicon
@@ -210,8 +233,6 @@ id: root
             source: "../assets/images/loading.png"
             width: vpx(50)
             height: vpx(50)
-            smooth: true
-            asynchronous: true
             RotationAnimator on rotation {
                 loops: Animator.Infinite;
                 from: 0;
@@ -220,7 +241,6 @@ id: root
             }
         }
     }
-    
     
     // List specific input
     Keys.onPressed: {

--- a/GridView/GridViewMenu.qml
+++ b/GridView/GridViewMenu.qml
@@ -36,6 +36,7 @@ id: root
     // Load settings
     property bool showBoxes: settings.GridThumbnail === "Box Art"
     property int numColumns: settings.GridColumns ? settings.GridColumns : 6
+    property int titleMargin: settings.AlwaysShowTitles === "Yes" ? vpx(30) : 0
 
     GridSpacer {
     id: fakebox
@@ -108,7 +109,7 @@ id: root
                 bottom: parent.bottom; bottomMargin: helpMargin + vpx(40)
             }
             cellWidth: width / numColumns
-            cellHeight: (showBoxes) ? cellWidth * cellHeightRatio : savedCellHeight
+            cellHeight: ((showBoxes) ? cellWidth * cellHeightRatio : savedCellHeight) + titleMargin
             preferredHighlightBegin: vpx(0)
             preferredHighlightEnd: gamegrid.height - helpMargin - vpx(40)
             highlightRangeMode: GridView.ApplyRange  
@@ -129,7 +130,7 @@ id: root
                     gameData: modelData
                     
                     width:      GridView.view.cellWidth
-                    height:     GridView.view.cellHeight
+                    height:     GridView.view.cellHeight - titleMargin
                     
                     onActivate: {
                         if (selected)
@@ -161,7 +162,7 @@ id: root
                     selected: GridView.isCurrentItem && root.focus
                     
                     width:      GridView.view.cellWidth
-                    height:     GridView.view.cellHeight
+                    height:     GridView.view.cellHeight - titleMargin
                     
                     onActivated: {
                         if (selected)

--- a/Settings/SettingsScreen.qml
+++ b/Settings/SettingsScreen.qml
@@ -47,6 +47,10 @@ id: root
             settingName: "Enable mouse hover"
             setting: "No,Yes"
         }
+        ListElement {
+            settingName: "Always show titles"
+            setting: "No,Yes"
+        }
     }
 
     property var generalPage: {

--- a/theme.qml
+++ b/theme.qml
@@ -47,6 +47,7 @@ id: root
             AllowThumbVideoAudio:          api.memory.has("Play video thumbnail audio") ? api.memory.get("Play video thumbnail audio") : "No",
             HideLogo:                      api.memory.has("Hide logo when thumbnail video plays") ? api.memory.get("Hide logo when thumbnail video plays") : "No",
             MouseHover:                    api.memory.has("Enable mouse hover") ? api.memory.get("Enable mouse hover") : "No",
+            AlwaysShowTitles:              api.memory.has("Always show titles") ? api.memory.get("Always show titles") : "No",
             AnimateHighlight:              api.memory.has("Animate highlight") ? api.memory.get("Animate highlight") : "No",
             AllowVideoPreviewAudio:        api.memory.has("Video preview audio") ? api.memory.get("Video preview audio") : "No",
             ShowScanlines:                 api.memory.has("Show scanlines") ? api.memory.get("Show scanlines") : "Yes",


### PR DESCRIPTION
This PR adds an option for persistent titles underneath games. (default: off)

I've also cleaned up the boxart view to be more consistent with the rest of the theme:

- Added border
- Semi-transparent overlay when item isn't selected
- Added loading indicator

I've also removed `asynchronous: true` from the loading-indicator. This causes the spinner image to be loaded at a higher priority and fixed an issue I was having where sometimes the loading indicator wouldn't appear.