### PR TITLE
Check for image status when showing default logo

### DIFF
--- a/Global/BoxArtGridItem.qml
+++ b/Global/BoxArtGridItem.qml
@@ -122,7 +122,7 @@ id: root
         font.family: subtitleFont.name
         font.bold: true
         style: Text.Outline; styleColor: theme.main
-        visible: screenshot.paintedWidth === 0
+        visible: screenshot.status === Image.Null || screenshot.status === Image.Error
         anchors.centerIn: parent
         elide: Text.ElideRight
         wrapMode: Text.WordWrap

--- a/Global/DynamicGridItem.qml
+++ b/Global/DynamicGridItem.qml
@@ -164,7 +164,7 @@ id: root
         font.family: subtitleFont.name
         font.bold: true
         style: Text.Outline; styleColor: theme.main
-        visible: favelogo.source == ""
+        visible: favelogo.status === Image.Null || favelogo.status === Image.Error
         anchors.centerIn: parent
         elide: Text.ElideRight
         wrapMode: Text.WordWrap


### PR DESCRIPTION
Fixes a bug where the default logo text would be visible while boxart was loading