### PR TITLE
Add support for SVG logo files with fall back to PNG and Text

### DIFF
--- a/ShowcaseView/ShowcaseViewMenu.qml
+++ b/ShowcaseView/ShowcaseViewMenu.qml
@@ -497,7 +497,12 @@ id: root
                     font.family: subtitleFont.name
                     font.bold: true
                     style: Text.Outline; styleColor: theme.main
-                    visible: collectionlogo.status == Image.Error
+
+					// show text when there's no PNG or SVG
+					visible: {
+						if (collectionlogo.status == Image.Error && collectionlogosvg.status == Image.Error) return true;
+						else return false;
+					}
                     anchors.centerIn: parent
                     elide: Text.ElideRight
                     wrapMode: Text.WordWrap

--- a/ShowcaseView/ShowcaseViewMenu.qml
+++ b/ShowcaseView/ShowcaseViewMenu.qml
@@ -450,13 +450,31 @@ id: root
 
                 anchors.verticalCenter: parent.verticalCenter
 
+				property var platformFilename: Utils.processPlatformName(modelData.shortName)
+
+                Image {
+                id: collectionlogosvg
+
+                    anchors.fill: parent
+                    anchors.centerIn: parent
+                    anchors.margins: vpx(15)
+                    source: "../assets/images/logossvg/" + platformFilename + ".svg"
+                    sourceSize: Qt.size(collectionlogosvg.width, collectionlogosvg.height)
+                    fillMode: Image.PreserveAspectFit
+                    asynchronous: true
+                    smooth: true
+                    opacity: selected ? 1 : 0.2
+                    scale: selected ? 1.1 : 1
+                    Behavior on scale { NumberAnimation { duration: 100 } }
+                }
+
                 Image {
                 id: collectionlogo
 
                     anchors.fill: parent
                     anchors.centerIn: parent
                     anchors.margins: vpx(15)
-                    source: "../assets/images/logospng/" + Utils.processPlatformName(modelData.shortName) + ".png"
+                    source: "../assets/images/logospng/" + platformFilename + ".png"
                     sourceSize: Qt.size(collectionlogo.width, collectionlogo.height)
                     fillMode: Image.PreserveAspectFit
                     asynchronous: true
@@ -464,6 +482,7 @@ id: root
                     opacity: selected ? 1 : 0.2
                     scale: selected ? 1.1 : 1
                     Behavior on scale { NumberAnimation { duration: 100 } }
+                    visible: collectionlogosvg.status == Image.Error
                 }
 
                 Text {


### PR DESCRIPTION
Loads and displays SVG logo image if it exists
Loads PNG logo image if it exists, but only displays if there is no SVG
Displays Text platform name if there is no SVG *and* there is no PNG