### PR TITLE
Fix for header bar labels (list mode) and page up/down functionality

### DIFF
--- a/Global/HeaderBar.qml
+++ b/Global/HeaderBar.qml
@@ -250,7 +250,7 @@ id: root
                 Text {
                 id: ordertitle
                     
-                    text: "By " + sortByFilter[sortByIndex]
+                    text: "By " + sortByDisplay[sortByIndex]
                                     
                     color: theme.text
                     font.family: subtitleFont.name

--- a/GridView/GridViewMenu.qml
+++ b/GridView/GridViewMenu.qml
@@ -64,7 +64,7 @@ id: root
             return false;
         }
 
-        if (sortByFilter[sortByIndex].toLowerCase() != "title") {
+        if (sortByFilter[sortByIndex].toLowerCase() != "sort_title") {
             return false;
         }
 

--- a/theme.qml
+++ b/theme.qml
@@ -89,6 +89,7 @@ id: root
     // Filtering options
     property bool showFavs: false
     property var sortByFilter: ["sort_title", "lastPlayed", "playCount", "rating"]
+    property var sortByDisplay: ["title", "last played", "play count", "rating"]
     property int sortByIndex: 0
     property var orderBy: Qt.AscendingOrder
     property string searchTerm: ""


### PR DESCRIPTION
Implements the following hotfixes:
- The header bar now displays proper labels to indicate the list mode.
- Restoring/fixing the page up/down function.